### PR TITLE
Add precompiled benchmarks for Mond to show only runtime performance

### DIFF
--- a/ScriptingBenchmark.Mond/MondPrecompiledBenchmark.cs
+++ b/ScriptingBenchmark.Mond/MondPrecompiledBenchmark.cs
@@ -1,0 +1,74 @@
+﻿using Mond;
+using ScriptingBenchmark.Shared;
+
+namespace ScriptingBenchmark.Mond;
+
+public class MondPrecompiledBenchmark : IBenchmarkableAsync
+{
+    public int LoopCount { get; private set; }
+
+    public MondState MondVM { get; private set; }
+    
+    public MondProgram CSharpToLangCode { get; private set; }
+    public MondProgram LangToCSharpCode { get; private set; }
+    public MondProgram LangAllocCode { get; private set; }
+
+    public MondPrecompiledBenchmark(int loopCount)
+    {
+        LoopCount = loopCount;
+    }
+
+    
+    public void Setup()
+    {
+        CSharpToLangCode = MondProgram.Compile(Codes.GetMondCSharpToLang());
+        LangToCSharpCode = MondProgram.Compile(Codes.GetMondLangToCSharp(LoopCount));
+        LangAllocCode = MondProgram.Compile(Codes.GetMondAlloc(LoopCount));
+        
+        MondVM = new MondState();
+        //Increment function for MondOUT
+        MondVM["increment"] = MondValue.Function((_, args) => args[0] += 1);
+    }
+
+    public void Cleanup()
+    {
+        
+    }
+
+    public int CSharpToLang()
+    {
+        MondValue func = MondVM.Load(CSharpToLangCode);
+
+        var number = 0;
+
+        for (int i = 0; i < LoopCount; i++)
+        {
+            var funcResult = MondVM.Call(func, number);
+            number = (int)funcResult;
+        }
+
+        return number;
+    }
+
+    public int LangToCSharp()
+    {
+        MondValue result = MondVM.Load(LangToCSharpCode);
+
+        var number = (int)result;
+        return number;
+    }
+
+    public string LangAlloc()
+    {
+        MondValue result = MondVM.Load(LangAllocCode);
+
+        return result[LoopCount - 1]["test"];
+    }
+
+    public async Task<int> CSharpToLangAsync() => CSharpToLang();
+    
+    public async Task<int> LangToCSharpAsync() => LangToCSharp();
+
+    public async Task<string> LangAllocAsync() => LangAlloc();
+    
+}

--- a/ScriptingBenchmark/Benchmark.cs
+++ b/ScriptingBenchmark/Benchmark.cs
@@ -23,6 +23,7 @@ public class Benchmark
 
     public IBenchmarkableAsync LuaCSharpBenchmark { get; private set; }
     public IBenchmarkableAsync MondBenchmark { get; private set; }
+    public IBenchmarkableAsync MondPrecompiledBenchmark { get; private set; }
     public IBenchmarkableAsync MoonSharpBenchmark { get; private set; }
     public IBenchmarkableAsync LuaNETBenchmark { get; private set; }
     public IBenchmarkableAsync JintBenchmark { get; private set; }
@@ -35,6 +36,9 @@ public class Benchmark
 
         MondBenchmark = new MondBenchmark(LoopCount);
         MondBenchmark.Setup();
+
+        MondPrecompiledBenchmark = new MondPrecompiledBenchmark(LoopCount);
+        MondPrecompiledBenchmark.Setup();
 
         MoonSharpBenchmark = new MoonsharpBenchmark(LoopCount);
         MoonSharpBenchmark.Setup();
@@ -51,6 +55,7 @@ public class Benchmark
     {
         LuaCSharpBenchmark.Cleanup();
         MondBenchmark.Cleanup();
+        MondPrecompiledBenchmark.Cleanup();
         MoonSharpBenchmark.Cleanup();
         LuaNETBenchmark.Cleanup();
         JintBenchmark.Cleanup();
@@ -64,6 +69,10 @@ public class Benchmark
     [BenchmarkCategory("CSharpToLang")]
     [Benchmark]
     public int MondCSharpToLang() => MondBenchmark.CSharpToLang();
+    
+    [BenchmarkCategory("CSharpToLang")]
+    [Benchmark]
+    public int MondPrecompiledCSharpToLang() => MondPrecompiledBenchmark.CSharpToLang();
     
     [BenchmarkCategory("CSharpToLang")]
     [Benchmark]
@@ -88,6 +97,10 @@ public class Benchmark
     
     [BenchmarkCategory("LangToCSharp")]
     [Benchmark]
+    public int MondPrecompiledLangToCSharp() => MondPrecompiledBenchmark.LangToCSharp();
+    
+    [BenchmarkCategory("LangToCSharp")]
+    [Benchmark]
     public int MoonSharpLangToCSharp() => MoonSharpBenchmark.LangToCSharp();
     
     [BenchmarkCategory("LangToCSharp")]
@@ -106,6 +119,10 @@ public class Benchmark
     [BenchmarkCategory("Alloc")]
     [Benchmark]
     public string MondAlloc() => MondBenchmark.LangAlloc();
+    
+    [BenchmarkCategory("Alloc")]
+    [Benchmark]
+    public string MondPrecompiledAlloc() => MondPrecompiledBenchmark.LangAlloc();
     
     [BenchmarkCategory("Alloc")]
     [Benchmark]


### PR DESCRIPTION
Hi there, I made Mond - thanks for setting this up! I went in to check why Mond is so slow and saw that the script parsing and compilation time is included in the benchmarks. This isn't ideal because most real world use cases of scripting languages would leverage cached compilations of scripts when possible.

This PR adds a new set of Mond benchmarks that compile the source script once and then reuse it across all runs. See comparison below:

```
| Method                      | LoopCount | Mean       | Error     | StdDev    | Rank | Gen0   | Gen1   | Allocated |
|---------------------------- |---------- |-----------:|----------:|----------:|-----:|-------:|-------:|----------:|
| MondAlloc                   | 100       | 104.054 us | 1.9105 us | 1.7871 us |    2 | 7.0801 | 1.5869 | 352.52 KB |
| MondPrecompiledAlloc        | 100       |  30.490 us | 0.5598 us | 0.5236 us |    1 | 1.8311 | 0.2441 |  91.39 KB |
|                             |           |            |           |           |      |        |        |           |
| MondCSharpToLang            | 100       |  70.209 us | 0.7220 us | 0.6753 us |    2 | 5.2490 | 0.6104 | 260.46 KB |
| MondPrecompiledCSharpToLang | 100       |   6.617 us | 0.1320 us | 0.1296 us |    1 | 0.4654 |      - |  22.96 KB |
|                             |           |            |           |           |      |        |        |           |
| MondLangToCSharp            | 100       |  78.704 us | 1.4717 us | 1.3766 us |    2 | 5.4932 | 0.4883 | 271.41 KB |
| MondPrecompiledLangToCSharp | 100       |   8.487 us | 0.1691 us | 0.1809 us |    1 | 0.3052 |      - |  15.11 KB |
```

Mond's compiler adds a lot of overhead! I never bothered to optimize it and it shows. Doesn't help that it compiles from an `IEnumerable<char>` instead of a flat buffer. Can do cool stuff with that though - check out MondKeyboard.

I am not familiar with the other benchmarked libraries but they should all have similar functionality to only compile once. I think it's worth adding similar benchmarks for everything else.